### PR TITLE
Make StStShared binding behave like StructStore binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,9 +116,8 @@ std::cout << "settings struct: " << *shsettings_store << std::endl;
 
 ```python
 shmem = structstore.StructStoreShared("/shdata_store")
-shstore = shmem.get_store()
-shstore.state = State(5, 'foo', True, Substate(42), [0, 1])
-print(shstore.deepcopy())
+shmem.state = State(5, 'foo', True, Substate(42), [0, 1])
+print(shmem.deepcopy())
 ```
 
 ## Implementation details

--- a/examples/example.py
+++ b/examples/example.py
@@ -33,9 +33,8 @@ def __main__():
     print(state.deepcopy())
 
     shmem = structstore.StructStoreShared("/dyn_shdata_store", 16384)
-    shstore = shmem.get_store()
-    shstore.state = State(5, 3.14, 'foo', True, Substate(42), [0, 1])
-    print(shstore.deepcopy())
+    shmem.state = State(5, 3.14, 'foo', True, Substate(42), [0, 1])
+    print(shmem.deepcopy())
 
     shmem2 = structstore.StructStoreShared("/dyn_settings")
     settings = shmem2.get_store()

--- a/examples/example.py
+++ b/examples/example.py
@@ -37,8 +37,7 @@ def __main__():
     print(shmem.deepcopy())
 
     shmem2 = structstore.StructStoreShared("/dyn_settings")
-    settings = shmem2.get_store()
-    print(settings.deepcopy())
+    print(shmem2.deepcopy())
 
 
 if __name__ == '__main__':

--- a/examples/example_imviz.py
+++ b/examples/example_imviz.py
@@ -32,13 +32,11 @@ class ExampleGui:
         print(self.state.to_yaml())
 
         self.shmem = structstore.StructStoreShared("/shdata_store", 16384)
-        self.shstate = self.shmem.get_store()
-        self.shstate.state = State(5, 'foo', True, Substate(42))
-        self.shstate.vec = np.array([[1.0, 2.0], [3.0, 4.0]])
+        self.shmem.state = State(5, 'foo', True, Substate(42))
+        self.shmem.vec = np.array([[1.0, 2.0], [3.0, 4.0]])
         self.num_cnt = 0
 
         self.shmem2 = structstore.StructStoreShared("/shsettings_store")
-        self.shsettings = self.shmem2.get_store()
 
 
     def update_gui(self):
@@ -48,13 +46,13 @@ class ExampleGui:
             viz.autogui(self.state.deepcopy())
         viz.end_window()
         if viz.begin_window('SharedState'):
-            viz.autogui(self.shstate)
+            viz.autogui(self.shmem)
             if viz.button('Add number'):
-                setattr(self.shstate, f'num{self.num_cnt}', self.num_cnt)
+                setattr(self.shmem, f'num{self.num_cnt}', self.num_cnt)
                 self.num_cnt += 1
         viz.end_window()
         if viz.begin_window('SharedSettings'):
-            viz.autogui(self.shsettings)
+            viz.autogui(self.shmem2)
         viz.end_window()
         end = timeit.default_timer()
         if random.random() < 0.01:

--- a/src/structstore.hpp
+++ b/src/structstore.hpp
@@ -86,8 +86,6 @@ public:
 };
 
 class StructStore {
-    friend void register_structstore_pybind(pybind11::module_&);
-
     friend class StructStoreShared;
 
     friend class FieldAccess;
@@ -201,6 +199,10 @@ public:
 
     [[nodiscard]] auto read_lock() const {
         return ScopedLock(mutex);
+    }
+
+    const vector<HashString>& get_slots() const {
+        return slots;
     }
 };
 

--- a/src/structstore_pybind.cpp
+++ b/src/structstore_pybind.cpp
@@ -205,7 +205,6 @@ void register_structstore_pybind(py::module_& m) {
                 return res;
               },
               py::arg("block") = true);
-    shcls.def("get_store", &StructStoreShared::operator*, py::return_value_policy::reference_internal);
 
     auto list = py::class_<List>(m, "StructStoreList");
     list.def("__repr__", [](const List& list) {

--- a/src/structstore_pybind.cpp
+++ b/src/structstore_pybind.cpp
@@ -123,19 +123,18 @@ py::object to_object(const StructStore& store) {
     return obj;
 }
 
-void register_structstore_pybind(py::module_& m) {
-    SimpleNamespace = py::module_::import("types").attr("SimpleNamespace");
-
-    py::class_<StructStore> cls = py::class_<StructStore>{m, "StructStore"};
-    cls.def(py::init<>());
-    cls.def_property_readonly("__slots__", [](StructStore& store) {
+template<typename T>
+void register_structstore_methods(py::class_<T>& cls) {
+    cls.def_property_readonly("__slots__", [](T& t) {
+        StructStore& store = t;
         auto ret = py::list();
-        for (const auto& str: store.slots) {
+        for (const auto& str: store.get_slots()) {
             ret.append(str.str);
         }
         return ret;
     });
-    cls.def("__getattr__", [](StructStore& store, const std::string& name) {
+    cls.def("__getattr__", [](T& t, const std::string& name) {
+        StructStore& store = t;
         auto lock = store.read_lock();
         StructStoreField* field = store.try_get_field(HashString{name.c_str()});
         if (field == nullptr) {
@@ -143,36 +142,52 @@ void register_structstore_pybind(py::module_& m) {
         }
         return to_object<false>(*field);
     }, py::return_value_policy::reference_internal);
-    cls.def("__setattr__", [](StructStore& store, const std::string& name, py::object value) {
+    cls.def("__setattr__", [](T& t, const std::string& name, py::object value) {
+        StructStore& store = t;
         auto lock = store.write_lock();
         from_object(store[name.c_str()], value);
     });
-    cls.def("to_yaml", [](StructStore& store) {
+    cls.def("to_yaml", [](T& t) {
+        StructStore& store = t;
         auto lock = store.read_lock();
         return YAML::Dump(to_yaml(store));
     });
-    cls.def("__repr__", [](StructStore& store) {
+    cls.def("__repr__", [](T& t) {
+        StructStore& store = t;
         auto lock = store.read_lock();
         std::ostringstream str;
         str << store;
         return str.str();
     });
-    cls.def("copy", [](StructStore& store) {
+    cls.def("copy", [](T& t) {
+        StructStore& store = t;
         auto lock = store.read_lock();
         return to_object<false>(store);
     });
-    cls.def("deepcopy", [](StructStore& store) {
+    cls.def("deepcopy", [](T& t) {
+        StructStore& store = t;
         auto lock = store.read_lock();
         return to_object<true>(store);
     });
-    cls.def("size", [](StructStore& store) {
+    cls.def("size", [](T& t) {
+        StructStore& store = t;
         return store.mm_alloc.get_size();
     });
-    cls.def("allocated", [](StructStore& store) {
+    cls.def("allocated", [](T& t) {
+        StructStore& store = t;
         return store.mm_alloc.get_allocated();
     });
+}
+
+void register_structstore_pybind(py::module_& m) {
+    SimpleNamespace = py::module_::import("types").attr("SimpleNamespace");
+
+    py::class_<StructStore> cls = py::class_<StructStore>{m, "StructStore"};
+    cls.def(py::init<>());
+    register_structstore_methods(cls);
 
     auto shcls = py::class_<StructStoreShared>(m, "StructStoreShared");
+    register_structstore_methods(shcls);
     shcls.def(py::init<const std::string&, ssize_t, bool>(),
               py::arg("path"),
               py::arg("size") = 2048,

--- a/src/structstore_pybind.cpp
+++ b/src/structstore_pybind.cpp
@@ -126,7 +126,7 @@ py::object to_object(const StructStore& store) {
 template<typename T>
 void register_structstore_methods(py::class_<T>& cls) {
     cls.def_property_readonly("__slots__", [](T& t) {
-        StructStore& store = t;
+        StructStore& store = static_cast<StructStore&>(t);
         auto ret = py::list();
         for (const auto& str: store.get_slots()) {
             ret.append(str.str);
@@ -134,7 +134,7 @@ void register_structstore_methods(py::class_<T>& cls) {
         return ret;
     });
     cls.def("__getattr__", [](T& t, const std::string& name) {
-        StructStore& store = t;
+        StructStore& store = static_cast<StructStore&>(t);
         auto lock = store.read_lock();
         StructStoreField* field = store.try_get_field(HashString{name.c_str()});
         if (field == nullptr) {
@@ -143,38 +143,38 @@ void register_structstore_methods(py::class_<T>& cls) {
         return to_object<false>(*field);
     }, py::return_value_policy::reference_internal);
     cls.def("__setattr__", [](T& t, const std::string& name, py::object value) {
-        StructStore& store = t;
+        StructStore& store = static_cast<StructStore&>(t);
         auto lock = store.write_lock();
         from_object(store[name.c_str()], value);
     });
     cls.def("to_yaml", [](T& t) {
-        StructStore& store = t;
+        StructStore& store = static_cast<StructStore&>(t);
         auto lock = store.read_lock();
         return YAML::Dump(to_yaml(store));
     });
     cls.def("__repr__", [](T& t) {
-        StructStore& store = t;
+        StructStore& store = static_cast<StructStore&>(t);
         auto lock = store.read_lock();
         std::ostringstream str;
         str << store;
         return str.str();
     });
     cls.def("copy", [](T& t) {
-        StructStore& store = t;
+        StructStore& store = static_cast<StructStore&>(t);
         auto lock = store.read_lock();
         return to_object<false>(store);
     });
     cls.def("deepcopy", [](T& t) {
-        StructStore& store = t;
+        StructStore& store = static_cast<StructStore&>(t);
         auto lock = store.read_lock();
         return to_object<true>(store);
     });
     cls.def("size", [](T& t) {
-        StructStore& store = t;
+        StructStore& store = static_cast<StructStore&>(t);
         return store.mm_alloc.get_size();
     });
     cls.def("allocated", [](T& t) {
-        StructStore& store = t;
+        StructStore& store = static_cast<StructStore&>(t);
         return store.mm_alloc.get_allocated();
     });
 }

--- a/src/structstore_shared.hpp
+++ b/src/structstore_shared.hpp
@@ -251,7 +251,7 @@ public:
         return shm_ptr->data;
     }
 
-    operator StructStore&() {
+    explicit operator StructStore&() {
         return shm_ptr->data;
     }
 

--- a/src/structstore_shared.hpp
+++ b/src/structstore_shared.hpp
@@ -251,6 +251,10 @@ public:
         return shm_ptr->data;
     }
 
+    operator StructStore&() {
+        return shm_ptr->data;
+    }
+
     FieldAccess operator[](HashString name) {
         return shm_ptr->data[name];
     }


### PR DESCRIPTION
This enables the usage of a StructStoreShared to be the same as that of a StructStore in Python, i.e. the call to `get_store()` and storing two separate objects is not necessary anymore.