### PR TITLE
Ensuring pybind11 is installed before setup.py is run

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,23 @@
+[build-system]
+requires = [
+    "setuptools>=61.0",
+    "pybind11>=2.10.0"
+]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "structstore"
+version = "0.0.1"
+authors = [
+  { name="Max Mertens", email="max.mail@dameweb.de" },
+]
+description="Structured object storage, dynamically typed, to be shared between processes"
+readme = "README.md"
+requires-python = ">=3.6"
+classifiers = [
+    "Programming Language :: Python :: 3",
+]
+
+[project.urls]
+"Homepage" = "https://github.com/jellysheep/structstore"
+"Bug Tracker" = "https://github.com/jellysheep/structstore/issues"


### PR DESCRIPTION
If pybind11 is not installed at build time (which is not ensured right now), the pybind11 import in the first line in ```setup.py``` fails.
The merge request adds a ```pyproject.toml``` file, which installs pybind11 before ```setup.py``` is run.
This is the approach also taken by the [pybind python example](https://github.com/pybind/python_example).