### PR TITLE
Locking capabilities and bug fixes

### DIFF
--- a/src/structstore.hpp
+++ b/src/structstore.hpp
@@ -209,6 +209,10 @@ public:
         return {get_field(HashString{name}), mm_alloc};
     }
 
+    SpinMutex& get_mutex() {
+        return mutex;
+    }
+
     [[nodiscard]] auto write_lock() {
         return ScopedLock(mutex);
     }

--- a/src/structstore_containers.hpp
+++ b/src/structstore_containers.hpp
@@ -87,6 +87,10 @@ public:
         return os << "]";
     }
 
+    SpinMutex& get_mutex() {
+        return mutex;
+    }
+
     size_t size() {
         return data.size();
     }

--- a/src/structstore_lock.hpp
+++ b/src/structstore_lock.hpp
@@ -6,9 +6,12 @@
 namespace structstore {
 
 class SpinMutex {
-    std::atomic_flag flag = ATOMIC_FLAG_INIT;
+    std::atomic_int flag{0};
+    int lock_level = 0;
 
 public:
+    inline static int pid = 1;
+
     SpinMutex() = default;
 
     SpinMutex(SpinMutex&&) = delete;
@@ -20,15 +23,22 @@ public:
     SpinMutex& operator=(const SpinMutex&) = delete;
 
     void lock() {
-        while (flag.test_and_set(std::memory_order_acquire)) {
-#if defined(__cpp_lib_atomic_flag_test)
-            while (flag.test(std::memory_order_relaxed));
-#endif
+        int v = flag.load(std::memory_order_relaxed);
+        if (v == pid) {
+            lock_level++;
+            return;
         }
+        v = 0;
+        while (!flag.compare_exchange_strong(v, pid, std::memory_order_acquire)) {
+            while ((v = flag.load(std::memory_order_relaxed)) != 0) { }
+        }
+        lock_level++;
     }
 
     void unlock() {
-        flag.clear(std::memory_order_release);
+        if ((lock_level -= 1) == 0) {
+            flag.store(0, std::memory_order_release);
+        }
     }
 };
 

--- a/src/structstore_shared.hpp
+++ b/src/structstore_shared.hpp
@@ -67,6 +67,8 @@ public:
           use_file{use_file},
           cleanup{cleanup}{
 
+        SpinMutex::pid = getpid();
+
         if (use_file) {
             fd = open(path.c_str(), O_EXCL | O_CREAT | O_RDWR, 0600);
         } else {

--- a/src/structstore_shared.hpp
+++ b/src/structstore_shared.hpp
@@ -247,6 +247,8 @@ public:
 
     bool revalidate(bool block = true) {
 
+        SpinMutex::pid = getpid();
+
         if (!sh_data_ptr->invalidated.load()) {
             return true;
         }


### PR DESCRIPTION
This pull request makes the following modifications to locks:

* Spin locks now use the current thread id as ```acquired``` state in the lock variable. This enables safe parallel processing for multiple processes and multiple threads.
* Spin locks are now reentrant by introducing a ```lock_level``` variable.
* For simple locking using the python interface a ```SpinLockContextManager``` is introduced, which is created by calling the ```.lock()``` function on any structstore object.

Further bugfixes:

* If the shared memory segment is found in not-ready state (```fd_state.st_mode != 0100660```) during the constructor execution, a ```std::runtime_error``` is thrown. In this case, the user has to simply try again. This ensures that there is no case, where the constructor leaves an uninitialized state. This closes #5.
* In the ```revalidate()``` function ```new_fd``` is now closed, if it contains a valid file descriptor. Previously there could be cases in non-blocking mode where ```new_fd``` was not closed, thus leaking open file descriptors.
* In the destructor the ```invalidated``` flag is now checked and set with an atomic operation. Only if ```invalidated == false``` the ```unlink()``` call is made. This ensures that even if ```cleanup == ALWAYS```, unlinking is done exactly once for each shared memory segment. Otherwise the could be cases, where an already newly initialized structstore was wrongly unlinked by another process, given that ```cleanup``` was set to ```ALWAYS```.