### PR TITLE
fixes copy for array views

### DIFF
--- a/src/structstore_pybind.cpp
+++ b/src/structstore_pybind.cpp
@@ -106,7 +106,7 @@ static void from_object(FieldAccess access, const py::handle& value, const std::
         }
     } else if (py::isinstance<py::array>(value)) {
         access.set_type<Matrix>();
-        auto array = value.cast<py::array>();
+        auto array = py::array_t<double, py::array::c_style | py::array::forcecast>::ensure(value);
         py::buffer_info info = array.request();
         if (info.format != py::format_descriptor<double>::format()) {
             throw std::runtime_error("Incompatible format: expected a double array!");


### PR DESCRIPTION
When copying slices (array views) to a structstore array, the data strides are not considered by the copy.
This leads to the wrong data being copied into the array. Consider the following example:
```
import numpy as np
import structstore as sts

store = sts.StructStore()
arr = np.zeros((4, 2))
arr[:, 0] = 1.0
arr[:, 1] = 0.0
store.arr = arr[:, 0]

print(store.arr)
```
It prints ```[1.0, 0.0, 1.0, 0.0]```. Not ```[1.0, 1.0, 1.0, 1.0]``` as one expects.

This pull request fixes the issues by including a conversion to a contiguous c-style array before the copy.