### PR TITLE
Fixed toml, support for writing dicts, __get/setitem__ methods

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,20 +4,3 @@ requires = [
     "pybind11>=2.10.0"
 ]
 build-backend = "setuptools.build_meta"
-
-[project]
-name = "structstore"
-version = "0.0.1"
-authors = [
-  { name="Max Mertens", email="max.mail@dameweb.de" },
-]
-description="Structured object storage, dynamically typed, to be shared between processes"
-readme = "README.md"
-requires-python = ">=3.6"
-classifiers = [
-    "Programming Language :: Python :: 3",
-]
-
-[project.urls]
-"Homepage" = "https://github.com/jellysheep/structstore"
-"Bug Tracker" = "https://github.com/jellysheep/structstore/issues"

--- a/src/structstore_pybind.cpp
+++ b/src/structstore_pybind.cpp
@@ -142,6 +142,22 @@ static void from_object(FieldAccess access, const py::handle& value, const std::
             std::string key_str = py::str(key);
             from_object(store[key_str.c_str()], py::getattr(value, key), py::str(key));
         }
+    } else if (py::isinstance<py::dict>(value)) {
+        access.set_type<StructStore>();
+        py::dict dict = py::cast<py::dict>(value);
+        StructStore& store = access.get<StructStore>();
+        store.clear();
+        for (auto& [key, val]: dict) {
+            if (!py::isinstance<py::str>(key)) {
+                std::ostringstream msg;
+                msg << "Key '" << py::str(key)
+                    << "' has unsupported type '" << py::str(key.get_type())
+                    << "'! Only string keys are supported.";
+                throw py::type_error(msg.str());
+            }
+            std::string key_str = py::str(key);
+            from_object(store[key_str.c_str()], dict[key], py::str(key));
+        }
     } else if (py::isinstance<py::none>(value)) {
         access.clear();
     } else {
@@ -212,7 +228,7 @@ void register_structstore_methods(py::class_<T>& cls) {
         }
         return ret;
     });
-    cls.def("__getattr__", [](T& t, const std::string& name) {
+    auto get_field = [](T& t, const std::string& name) {
         StructStore& store = static_cast<StructStore&>(t);
         auto lock = store.read_lock();
         StructStoreField* field = store.try_get_field(HashString{name.c_str()});
@@ -220,12 +236,16 @@ void register_structstore_methods(py::class_<T>& cls) {
             throw py::attribute_error();
         }
         return to_object<false>(*field);
-    }, py::return_value_policy::reference_internal);
-    cls.def("__setattr__", [](T& t, const std::string& name, py::object value) {
+    };
+    auto set_field = [](T& t, const std::string& name, py::object value) {
         StructStore& store = static_cast<StructStore&>(t);
         auto lock = store.write_lock();
         from_object(store[name.c_str()], value, name);
-    });
+    };
+    cls.def("__getattr__", get_field, py::return_value_policy::reference_internal);
+    cls.def("__setattr__", set_field);
+    cls.def("__getitem__", get_field, py::return_value_policy::reference_internal);
+    cls.def("__setitem__", set_field);
     cls.def("lock", [](T& t) {
         StructStore& store = static_cast<StructStore&>(t);
         store.get_mutex().lock();

--- a/src/structstore_pybind.cpp
+++ b/src/structstore_pybind.cpp
@@ -156,7 +156,7 @@ static void from_object(FieldAccess access, const py::handle& value, const std::
                 throw py::type_error(msg.str());
             }
             std::string key_str = py::str(key);
-            from_object(store[key_str.c_str()], dict[key], py::str(key));
+            from_object(store[key_str.c_str()], dict[key], key_str);
         }
     } else if (py::isinstance<py::none>(value)) {
         access.clear();


### PR DESCRIPTION
Multiple small improvements:

1.) The ```pyproject.toml``` file currently triggers warnings like this:
```
 ********************************************************************************
              ##########################################################################
              # configuration would be ignored/result in error due to `pyproject.toml` #
              ##########################################################################
      
              The following seems to be defined outside of `pyproject.toml`:
      
              `license = 'BSD-3-Clause'`
      
              According to the spec (see the link below), however, setuptools CANNOT
              consider this value unless `license` is listed as `dynamic`.
      
              https://packaging.python.org/en/latest/specifications/declaring-project-metadata/
      
              For the time being, `setuptools` will still consider the given value (as a
              **transitional** measure), but please note that future releases of setuptools will
              follow strictly the standard.
      
              To prevent this warning, you can list `license` under `dynamic` or alternatively
              remove the `[project]` table from your file and rely entirely on other means of
              configuration.
      
              By 2023-Oct-30, you need to update your project and remove deprecated calls
              or your builds will no longer be supported.
              ********************************************************************************
```
As the project metadata is already specified in ```setup.py```, I went with the last listed option an simply removed the ```[project]``` table.

2.) Python dictionaries can now be copied into the store without raising a type error. All keys are verified to have type string, otherwise a corresponding type error is thrown.

3.) Python bindings for ```StructStore``` and ```StructStoreShared``` now support the ```__getitem__``` and ```__setitem__``` methods for dict-like access.  